### PR TITLE
Added SPACE and ENTER key to be acceptable keys to move to the NEXT

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -7,6 +7,7 @@
 
 - All slides are plain-text files. 
 - Navigation using `j` / `k` or `n` / `p`.
+- You can also navigate to the next slide using `SPACE` or `ENTER`.
 - Text color and style formatting. 
 - Pure bash.
 

--- a/shlide
+++ b/shlide
@@ -151,7 +151,7 @@ main() {
         display "$(<"${slides[$i]}")" "${slides[$i]}" "$i" "${#slides[@]}"
         read -rsn1 input
         case "$input" in 
-            "j"|"n")
+            "j"|"n"|"")
                 ((++i))
                 ;;
             "k"|"p")


### PR DESCRIPTION
Hey so when I first tried out shlide (which I LOVE by the way) before reading the instructions on how to move to the next slide I instinctively tried using the space bar and the enter key to try and move on (also the arrow keys but thats for another PR ;P ) and unfortunately these didn't work then I read the manual and saw N and P for 'next' and 'previous' which is ace but I thought maybe you would be interested in having the space key as an acceptable key to move to the next slide.
So that is exactly what this tiny change does.
When read with -rsn1 is used the space key and enter key appear as just blank strings '' so i simply added that.

I hope this is ok? Feel free to ignore this if it doesn't align with your vision for the project!

Again this is a awesome project and I really like it well done!