### PR TITLE
Add man page in scdoc format

### DIFF
--- a/shlide.1.scd
+++ b/shlide.1.scd
@@ -1,0 +1,105 @@
+shlide(1) ["Version 1.0"]
+
+# NAME
+
+shlide - a slide deck presentation tool written in pure bash
+
+# SYNOPSIS
+
+shlide _deck-directory/_
+
+# DESCRIPTION 
+
+Create a directory for your slides. Name each slide starting with
+a number and a hyphen, like so:
+
+	$ mkdir deck++
+$ touch deck/1-first-slide.txt++
+$ touch deck/2-another.txt
+
+*Note*: Make sure to prefix the first 9 slides with a *0* (e.g. 01-foo.txt, 02-bar.txt ...), if you have more than 10 slides.
+
+Finally, run:
+
+	$ shlide deck/
+
+# CONTROLS
+
+Next slide:
+	*j*, *n*, *;*, *space*, *enter*
+
+Previous slide:
+	*k*, *p*, *,*, *backspace*
+
+Jump to first slide:
+	*0*
+
+Jump to last slide:
+	*G*
+
+Reload:
+	*r*
+
+Quit:
+	*q*
+
+# FORMATTING
+
+Slide content can be formatted like so:
+
+Welcome to ${GRN}shlide${RST}. ${STR}Here${RST} are a few bullet points:
+
+\- first point++
+\- second point++
+	\* ${ITA}sub point${RST}++
+	\* ${BLD}another${RST} sub point
+
+*Note*: Make sure to add ${RST} (reset) at the end.
+
+A full list of formatting options are below:
+
+## Colors
+
+[[ *Key*
+:- *Effect*
+|- BLK
+:- black
+|- RED
+:- red
+|- GRN
+:- green
+|- YLW
+:- yellow
+|- BLU
+:- blue
+|- PUR
+:- purple
+|- CYN
+:- cyan
+|- RST
+:- reset
+
+## Styles
+
+[[ *Key*
+:- *Effect*
+|- BLD
+:- bold
+|- DIM
+:- dim
+|- ITA
+:- italics
+|- UND
+:- underline
+|- FLS
+:- flashing
+|- REV
+:- reverse
+|- INV
+:- invert
+|- STR
+:- strikethrough
+
+# LICENSES
+
+shlide is licensed under the MIT license.


### PR DESCRIPTION
Hello, I have added a man page in [`scdoc`](https://git.sr.ht/~sircmpwn/scdoc/) format for shlide. It is modeled after the readme and is nearly a copy/paste plus some formatting changes to make it look nice.

`scdoc` is an extremely lightweight man page generator. To make the man page:

    $ scdoc < shlide.1.scd > shlide.1

Then to view it:

    $ man -l shlide.1

I would also like to make a PKGBUILD for shlide in the AUR, and the man page would be a part of the installed package. Other packages I maintain: https://aur.archlinux.org/packages/?K=krathalan&SeB=m

Please let me know of any adjustments that need to be made. I am also willing to be contacted in the future (krathalan@disroot.org `02AA A23A BDF1 D538 BD88 9D25 1AAD E5E7 28FF C667`) to make future updates to the man page.