### PR TITLE
Whenever the application finishes (die) the cursor is now returned to the top left of the user's terminal

### DIFF
--- a/shlide
+++ b/shlide
@@ -111,6 +111,7 @@ display() {
 die() {
     printf '\e[2J'
     printf '\e[?25h'
+    printf '\e[0H'
     exit 0
 }
 


### PR DESCRIPTION
Realised that the cursor was not immediately returning to the top left of the screen when the shlide script had finished so added this functionality to the die function so that no matter how the application finishes the cursor will be properly reset for the user to continue their terminal experience. 💻 